### PR TITLE
Fix link to Crashlytics issue

### DIFF
--- a/views/crashlytics.view.lkml
+++ b/views/crashlytics.view.lkml
@@ -209,7 +209,7 @@ view: crashlytics {
     }
     link: {
       label: "Crashlytics Issue"
-      url: "https://console.firebase.google.com/project/{{ project_._value }}/crashlytics/app/{{ platform_._value }}:{{ app_._value }}/issues/{{ issue_id._value }}"
+      url: "https://console.firebase.google.com/project/{{ project_._value }}/crashlytics/app/{{ platform_._value | downcase }}:{{ app_._value | replace:'_','.' }}/issues/{{ issue_id._value }}"
     }
   }
 


### PR DESCRIPTION
Was generating a link with `ANDROID:com_example_app` but `android:com.example.app` seems to be the correct form.

Using this refinement to fix in the meantime:

```
view: +crashlytics {
  dimension: issue_title {
    link: {
      label: "Crashlytics Issue (Fixed)"
      url: "https://console.firebase.google.com/project/{{ project_._value }}/crashlytics/app/{{ platform_._value | downcase }}:{{ app_._value | replace:'_','.' }}/issues/{{ issue_id._value }}"
    }
  }
}
```